### PR TITLE
Corrected Newtonsoft.Json Nuget dependency

### DIFF
--- a/minimal.nuspec
+++ b/minimal.nuspec
@@ -16,7 +16,7 @@
     <tags>xero api sdk</tags>
     <dependencies>
         <group>
-            <dependency id="NewtonSoft.Json" version="[9.0.1,)"/>            
+            <dependency id="Newtonsoft.Json" version="[9.0.1,)"/>            
         </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Orginally NewtonSoft.Json (capital S).

This caused a duplicate key exception during startup of referencing application if another library was used with a dependency on Newtonsoft.Json.